### PR TITLE
Fix flicker navigation

### DIFF
--- a/app/feeds/[feed_url]/index.tsx
+++ b/app/feeds/[feed_url]/index.tsx
@@ -4,6 +4,7 @@ import { usePreviousRoute } from "~/providers/PreviousRoute";
 import { useThemeContext } from "@/theme/ThemeProvider";
 import { FeedContentItem, HandleLinkData, HandleRouterLinkData } from "@/types";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { useCallback, useMemo } from "react";
 import { Text, View, StyleSheet } from "react-native";
 import { formatLastRefresh } from "~/formatters/timeFormatters";
 
@@ -19,18 +20,21 @@ export default function FeedPage() {
   const previousRoute = usePreviousRoute<{ article_url: string }>();
   const previousArticleUrl = previousRoute?.params?.article_url;
 
-  const getRouteLink = (link: string) =>
-    `/feeds/${encodeURIComponent(
-      feed_url,
-    )}/articles/${encodeURIComponent(link)}`;
+  const getRouteLink = useCallback(
+    (link: string) =>
+      `/feeds/${encodeURIComponent(feed_url)}/articles/${encodeURIComponent(link)}`,
+    [feed_url],
+  );
 
   // TODO: only important articles should have Hero
-  const htmlItems =
-    content?.length === 0
-      ? '<div class="no-new-conent">No new content for this feed</div>'
-      : content
-          ?.map(
-            ({ title, link, author, heroImage }: FeedContentItem) => `
+  const htmlItems = useMemo(() => {
+    if (content?.length === 0) {
+      return '<div class="no-new-conent">No new content for this feed</div>';
+    }
+    return (
+      content
+        ?.map(
+          ({ title, link, author, heroImage }: FeedContentItem) => `
             <div 
               class="item ${heroImage ? "with-hero" : ""}" 
               data-route-link="${getRouteLink(link)}" 
@@ -40,10 +44,15 @@ export default function FeedPage() {
               ${author ? '<p class="author">' + author + "</p>" : ""}
             </div>
           `,
-          )
-          .join("");
+        )
+        .join("") ?? ""
+    );
+  }, [content, getRouteLink]);
 
-  const html = `
+  // html does NOT include previousArticleUrl so the WebView source stays stable
+  // on navigation back. The highlight is applied via postLoadScript instead.
+  const html = useMemo(
+    () => `
     <style>
       .item {
         border-bottom: 1px solid ${colors.borderDark};
@@ -57,8 +66,6 @@ export default function FeedPage() {
       .item.with-hero {
         padding: ${sizes.s0_50}px 0;
       }
-
-      ${previousArticleUrl ? `.item[data-route-link*="${getRouteLink(previousArticleUrl)}"] { border-bottom-width: 5px; }` : ""}
 
       .title {
         color: ${colors.text};
@@ -107,7 +114,30 @@ export default function FeedPage() {
     </style>
 
     ${htmlItems}
-  `;
+  `,
+    [htmlItems, colors, fonts, sizes],
+  );
+
+  // Highlight the previously read article by injecting a style after load,
+  // without changing the WebView source (which would trigger a full reload).
+  const postLoadScript = useMemo(() => {
+    if (!previousArticleUrl) return undefined;
+    const routePath = getRouteLink(previousArticleUrl);
+    return `
+      (function() {
+        var items = document.querySelectorAll('[data-route-link]');
+        items.forEach(function(el) {
+          var link = el.getAttribute('data-route-link');
+          if (link && link.includes(${JSON.stringify(routePath)})) {
+            el.style.setProperty('border-bottom-width', '5px');
+          } else {
+            el.style.removeProperty('border-bottom-width');
+          }
+        });
+      })();
+      true;
+    `;
+  }, [previousArticleUrl, getRouteLink]);
 
   return (
     <>
@@ -156,6 +186,7 @@ export default function FeedPage() {
         <HTMLPagesNav
           name="feed"
           html={html}
+          postLoadScript={postLoadScript}
           actions={{
             top: {
               label: "Nothing",

--- a/app/feeds/[feed_url]/index.tsx
+++ b/app/feeds/[feed_url]/index.tsx
@@ -31,7 +31,7 @@ export default function FeedPage() {
 
   const htmlItems = useMemo(() => {
     if (content?.length === 0) {
-      return '<div class="no-new-conent">No new content for this feed</div>';
+      return '<div class="no-new-content">No new content for this feed</div>';
     }
     return (
       content
@@ -103,7 +103,7 @@ export default function FeedPage() {
         line-height: ${fonts.lineHeightComfortable}px;
       }
 
-      .no-new-conent {
+      .no-new-content {
         color: ${colors.text};
         font-size: ${fonts.fontSizeP}px;
         font-weight: bold;

--- a/app/feeds/[feed_url]/index.tsx
+++ b/app/feeds/[feed_url]/index.tsx
@@ -7,6 +7,7 @@ import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useCallback, useMemo } from "react";
 import { Text, View, StyleSheet } from "react-native";
 import { formatLastRefresh } from "~/formatters/timeFormatters";
+import { useWebViewHighlight } from "~/hooks/useWebViewHighlight";
 
 export default function FeedPage() {
   const { colors, fonts, sizes, style } = useStyles();
@@ -26,7 +27,8 @@ export default function FeedPage() {
     [feed_url],
   );
 
-  // TODO: only important articles should have Hero
+  const postLoadScript = useWebViewHighlight(previousArticleUrl, getRouteLink);
+
   const htmlItems = useMemo(() => {
     if (content?.length === 0) {
       return '<div class="no-new-conent">No new content for this feed</div>';
@@ -49,8 +51,6 @@ export default function FeedPage() {
     );
   }, [content, getRouteLink]);
 
-  // html does NOT include previousArticleUrl so the WebView source stays stable
-  // on navigation back. The highlight is applied via postLoadScript instead.
   const html = useMemo(
     () => `
     <style>
@@ -70,7 +70,7 @@ export default function FeedPage() {
       .title {
         color: ${colors.text};
         font-size: ${fonts.fontSizeH4}px;
-        line-height: ${fonts.lineHeightComfortable}px;
+        line-height: ${fonts.lineHeightMinimal}px;
         font-weight: bold;
         margin: 0;
       }
@@ -117,27 +117,6 @@ export default function FeedPage() {
   `,
     [htmlItems, colors, fonts, sizes],
   );
-
-  // Highlight the previously read article by injecting a style after load,
-  // without changing the WebView source (which would trigger a full reload).
-  const postLoadScript = useMemo(() => {
-    if (!previousArticleUrl) return undefined;
-    const routePath = getRouteLink(previousArticleUrl);
-    return `
-      (function() {
-        var items = document.querySelectorAll('[data-route-link]');
-        items.forEach(function(el) {
-          var link = el.getAttribute('data-route-link');
-          if (link && link.includes(${JSON.stringify(routePath)})) {
-            el.style.setProperty('border-bottom-width', '5px');
-          } else {
-            el.style.removeProperty('border-bottom-width');
-          }
-        });
-      })();
-      true; // required by injectJavaScript — the script must evaluate to true
-    `;
-  }, [previousArticleUrl, getRouteLink]);
 
   return (
     <>

--- a/app/feeds/[feed_url]/index.tsx
+++ b/app/feeds/[feed_url]/index.tsx
@@ -135,7 +135,7 @@ export default function FeedPage() {
           }
         });
       })();
-      true;
+      true; // required by injectJavaScript — the script must evaluate to true
     `;
   }, [previousArticleUrl, getRouteLink]);
 

--- a/app/feeds/[feed_url]/index.tsx
+++ b/app/feeds/[feed_url]/index.tsx
@@ -60,11 +60,11 @@ export default function FeedPage() {
         flex-direction: column;
         padding: ${sizes.s1}px 0;
         text-decoration: none;
-        break-inside: avoid;
+        break-inside: avoid-column;
       }
 
       .item.with-hero {
-        padding: ${sizes.s0_50}px 0;
+        padding: 0 0 ${sizes.s1}px 0;
       }
 
       .title {
@@ -79,8 +79,8 @@ export default function FeedPage() {
         color: ${colors.text};
         font-size: ${fonts.fontSizeSmall}px;
         font-style: italic;
-        line-height: ${fonts.lineHeightComfortable}px;
-        margin: 0;
+        line-height: ${fonts.lineHeightMinimal}px;
+        margin: ${sizes.s0_25}px 0 0 0;
       }
 
       .hero-image {

--- a/app/feeds/index.tsx
+++ b/app/feeds/index.tsx
@@ -63,7 +63,7 @@ export default function Feeds() {
   const htmlItems = useMemo(
     () =>
       visibleFeeds?.length === 0
-        ? '<div class="no-new-conent"><h3>No content to show.</h3> <p>Swipe down to get updates <br />or add a new feed.</p></div>'
+        ? '<div class="no-new-content"><h3>No content to show.</h3> <p>Swipe down to get updates <br />or add a new feed.</p></div>'
         : visibleFeeds
             ?.map(
               ({ name, url }: any) => `
@@ -99,7 +99,7 @@ export default function Feeds() {
         margin: 0;
       }
 
-      .no-new-conent {
+      .no-new-content {
         color: ${colors.text};
         font-size: ${fonts.fontSizeP}px;
         font-weight: bold;

--- a/app/feeds/index.tsx
+++ b/app/feeds/index.tsx
@@ -1,6 +1,6 @@
 import { Link, Stack, useRouter } from "expo-router";
 import { Pressable, Text, StyleSheet, View } from "react-native";
-import { useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { HandleRouterLinkData } from "@/types";
 import { useThemeContext } from "@/theme/ThemeProvider";
 import { HTMLPagesNav } from "@/components/HTMLPagesNav";
@@ -9,6 +9,7 @@ import { usePreviousRoute } from "~/providers/PreviousRoute";
 import { useFeedsContext } from "@/providers/FeedsProvider";
 import { MaterialIcons } from "@expo/vector-icons";
 import { formatLastRefresh } from "~/formatters/timeFormatters";
+import { useWebViewHighlight } from "~/hooks/useWebViewHighlight";
 
 export default function Feeds() {
   const { colors, fonts, sizes, style } = useStyles();
@@ -45,32 +46,41 @@ export default function Feeds() {
   const [resetNavigation, setResetNavigation] = useState(1);
 
   const previousRoute = usePreviousRoute<{ feed_url: string }>();
-  const previousArticleUrl = previousRoute?.params?.feed_url;
+  const previousFeedUrl = previousRoute?.params?.feed_url;
 
-  const getRouteLink = (link: string) => `/feeds/${encodeURIComponent(link)}`;
+  const getRouteLink = useCallback(
+    (link: string) => `/feeds/${encodeURIComponent(link)}`,
+    [],
+  );
+
+  const postLoadScript = useWebViewHighlight(previousFeedUrl, getRouteLink);
 
   const visibleFeeds = feeds?.filter(
     ({ url }) =>
       feedArticleCounts[url] !== undefined && feedArticleCounts[url] > 0,
   );
 
-  const htmlItems =
-    visibleFeeds?.length === 0
-      ? '<div class="no-new-conent"><h3>No content to show.</h3> <p>Swipe down to get updates <br />or add a new feed.</p></div>'
-      : visibleFeeds
-          ?.map(
-            ({ name, url }: any) => `
-            <div 
-              class="item" 
-              data-route-link="${getRouteLink(url)}" 
-            >
-              <h3 class="title">${name}${feedArticleCounts[url] !== undefined ? ` (${feedArticleCounts[url]})` : ""}</h3>
-            </div>
-          `,
-          )
-          .join("");
+  const htmlItems = useMemo(
+    () =>
+      visibleFeeds?.length === 0
+        ? '<div class="no-new-conent"><h3>No content to show.</h3> <p>Swipe down to get updates <br />or add a new feed.</p></div>'
+        : visibleFeeds
+            ?.map(
+              ({ name, url }: any) => `
+              <div 
+                class="item" 
+                data-route-link="${getRouteLink(url)}" 
+              >
+                <h3 class="title">${name}${feedArticleCounts[url] !== undefined ? ` (${feedArticleCounts[url]})` : ""}</h3>
+              </div>
+            `,
+            )
+            .join(""),
+    [visibleFeeds, feedArticleCounts, getRouteLink],
+  );
 
-  const html = `
+  const html = useMemo(
+    () => `
     <style>
       .item {
         border-bottom: 1px solid ${colors.borderDark};
@@ -80,8 +90,6 @@ export default function Feeds() {
         text-decoration: none;
         break-inside: avoid;
       }
-
-      ${previousArticleUrl ? `.item[data-route-link*="${getRouteLink(previousArticleUrl)}"] { border-bottom-width: 5px; }` : ""}
 
       .title {
         color: ${colors.text};
@@ -102,7 +110,9 @@ export default function Feeds() {
     </style>
 
     ${htmlItems}
-  `;
+  `,
+    [htmlItems, colors, fonts, sizes],
+  );
 
   return (
     <>
@@ -195,6 +205,7 @@ export default function Feeds() {
           key={resetNavigation}
           name="feed"
           html={html}
+          postLoadScript={postLoadScript}
           actions={{
             top: {
               label: "Refresh All Feeds",

--- a/components/HTMLPagesNav/PageIndicator.tsx
+++ b/components/HTMLPagesNav/PageIndicator.tsx
@@ -34,7 +34,7 @@ function useStyles() {
       justifyContent: "flex-end",
       alignItems: "baseline",
       width: "100%",
-      paddingTop: sizes.s1,
+      paddingTop: 0,
       paddingBottom: sizes.s1,
       paddingLeft: sizes.s1,
       paddingRight: sizes.s1,

--- a/components/HTMLPagesNav/index.tsx
+++ b/components/HTMLPagesNav/index.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/types";
 import { PageIndicator } from "./PageIndicator";
 import { getWebViewEvents } from "./webViewEvents";
-import { useFocusEffect } from "expo-router";
 
 type HTMLPaesNavProps = {
   name: string;
@@ -80,15 +79,9 @@ export function HTMLPagesNavComponent({
   const handleScroll = useCallback((scrollLeft: number) => {
     webviewRef.current?.injectJavaScript(`
       document.getElementById("viewport").scrollLeft = ${scrollLeft};
-      true;
+      true; // required by injectJavaScript — the script must evaluate to true
     `);
   }, []);
-
-  // useFocusEffect(
-  //   useCallback(() => {
-  //     handleScroll(pages.scrollLeft);
-  //   }, [pages.scrollLeft, handleScroll]),
-  // );
 
   // Inject postLoadScript whenever it changes (e.g. highlight on navigation back)
   // without needing the WebView to reload.

--- a/components/HTMLPagesNav/index.tsx
+++ b/components/HTMLPagesNav/index.tsx
@@ -1,6 +1,6 @@
 import { useThemeContext } from "@/theme/ThemeProvider";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { StyleSheet, Dimensions, Animated, View } from "react-native";
+import { StyleSheet, Dimensions, Animated, View, Text } from "react-native";
 import { WebView, WebViewMessageEvent } from "react-native-webview";
 import {
   getHorizontalNavigationPage,
@@ -44,6 +44,7 @@ export function HTMLPagesNavComponent({
     isFirst: true,
     isLast: false,
   } as unknown as Pages);
+  const [loadError, setLoadError] = useState(false);
   const { panResponder, pan, labelsOpacity, opacity } = usePanResponder({
     name,
     width,
@@ -71,6 +72,7 @@ export function HTMLPagesNavComponent({
     SWIPE_TOP,
     SWIPE_BOTTOM,
     ON_LOAD,
+    ON_LOAD_ERROR,
     HANDLE_LINK,
     HANDLE_ROUTER_LINK,
     _CONSOLE_,
@@ -164,8 +166,11 @@ export function HTMLPagesNavComponent({
         }
         return;
       }
+      case ON_LOAD_ERROR:
+        console.error("[HTMLPagesNav]", data.message);
+        setLoadError(true);
+        return;
       case HANDLE_LINK:
-        return handleLink && handleLink(data);
       case HANDLE_ROUTER_LINK:
         return handleRouterLink && handleRouterLink(data);
       case _CONSOLE_:
@@ -215,6 +220,12 @@ export function HTMLPagesNavComponent({
           injectedJavaScript={script(webViewEvents)}
         />
 
+        {loadError && (
+          <View style={styles.errorContainer}>
+            <Text style={styles.errorText}>Content could not be rendered.</Text>
+          </View>
+        )}
+
         <PageIndicator pages={pages} />
       </Animated.View>
     </View>
@@ -223,7 +234,7 @@ export function HTMLPagesNavComponent({
 
 function useStyles(windowWidth: number) {
   const { theme } = useThemeContext();
-  const { sizes, colors } = theme;
+  const { sizes, colors, fonts } = theme;
 
   const webViewWidth = () => {
     const screenWidth = windowWidth - sizes.s1 * 2;
@@ -256,6 +267,18 @@ function useStyles(windowWidth: number) {
       position: "absolute",
       height: "100%",
       width: "100%",
+    },
+    errorContainer: {
+      position: "absolute",
+      height: "100%",
+      width: "100%",
+      justifyContent: "flex-start",
+      alignItems: "flex-start",
+      padding: sizes.s1,
+    },
+    errorText: {
+      color: colors.text,
+      fontSize: fonts.fontSizeP,
     },
   });
 

--- a/components/HTMLPagesNav/index.tsx
+++ b/components/HTMLPagesNav/index.tsx
@@ -1,5 +1,5 @@
 import { useThemeContext } from "@/theme/ThemeProvider";
-import { memo, useCallback, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { StyleSheet, Dimensions, Animated, View } from "react-native";
 import { WebView, WebViewMessageEvent } from "react-native-webview";
 import {
@@ -24,6 +24,7 @@ type HTMLPaesNavProps = {
   actions: HTMLPagesNavActions;
   handleLink?: (data: HandleLinkData) => void;
   handleRouterLink?: (data: HandleRouterLinkData) => void;
+  postLoadScript?: string;
 };
 
 export function HTMLPagesNavComponent({
@@ -32,11 +33,14 @@ export function HTMLPagesNavComponent({
   actions,
   handleLink,
   handleRouterLink,
+  postLoadScript,
 }: HTMLPaesNavProps) {
   const webviewRef = useRef<WebView>(null);
   const { width, height } = Dimensions.get("window");
   const { styles, theme } = useStyles(width);
   const [pages, setPages] = useState<Pages>({
+    amount: 0,
+    current: 0,
     scrollLeft: 0,
     isFirst: true,
     isLast: false,
@@ -48,11 +52,18 @@ export function HTMLPagesNavComponent({
     webviewRef,
   });
 
-  const content = getHorizontalNavigationPage({
-    content: html,
-    width: styles.webView.width,
-    theme,
-  });
+  const content = useMemo(
+    () =>
+      getHorizontalNavigationPage({
+        content: html,
+        width: styles.webView.width,
+        theme,
+      }),
+    [html, styles.webView.width, theme],
+  );
+
+  // Memoize source object so the WebView only reloads when content actually changes.
+  const source = useMemo(() => ({ html: content }), [content]);
 
   const webViewEvents = getWebViewEvents(name);
   const {
@@ -73,7 +84,19 @@ export function HTMLPagesNavComponent({
     `);
   }, []);
 
-  useFocusEffect(() => handleScroll(pages.scrollLeft));
+  // useFocusEffect(
+  //   useCallback(() => {
+  //     handleScroll(pages.scrollLeft);
+  //   }, [pages.scrollLeft, handleScroll]),
+  // );
+
+  // Inject postLoadScript whenever it changes (e.g. highlight on navigation back)
+  // without needing the WebView to reload.
+  useEffect(() => {
+    if (postLoadScript) {
+      webviewRef.current?.injectJavaScript(postLoadScript);
+    }
+  }, [postLoadScript]);
 
   // Receives messages from JS inside page content
   const onMessage = (event: WebViewMessageEvent) => {
@@ -140,7 +163,13 @@ export function HTMLPagesNavComponent({
       case SWIPE_BOTTOM:
         return actions.bottom && actions.bottom.action();
       case ON_LOAD: {
-        return handlePages();
+        handlePages();
+        // Safety net: also inject postLoadScript after a reload
+        // (useEffect covers the no-reload case on navigation back)
+        if (postLoadScript) {
+          webviewRef.current?.injectJavaScript(postLoadScript);
+        }
+        return;
       }
       case HANDLE_LINK:
         return handleLink && handleLink(data);
@@ -184,7 +213,7 @@ export function HTMLPagesNavComponent({
           ref={webviewRef}
           style={[styles.webView, { opacity: pages.amount > 0 ? 1 : 0 }]}
           originWhitelist={["*"]}
-          source={{ html: content }}
+          source={source}
           showsHorizontalScrollIndicator={false}
           showsVerticalScrollIndicator={false}
           scrollEnabled={false}

--- a/components/HTMLPagesNav/webViewEvents.ts
+++ b/components/HTMLPagesNav/webViewEvents.ts
@@ -7,6 +7,7 @@ export function getWebViewEvents(webViewName: string) {
     SWIPE_TOP: name("SWIPE_TOP"),
     SWIPE_BOTTOM: name("SWIPE_BOTTOM"),
     ON_LOAD: name("ON_LOAD"),
+    ON_LOAD_ERROR: name("ON_LOAD_ERROR"),
     HANDLE_LINK: name("HANDLE_LINK"),
     HANDLE_ROUTER_LINK: name("HANDLE_ROUTER_LINK"),
     _CONSOLE_: name("_CONSOLE_"),

--- a/hooks/useWebViewHighlight.ts
+++ b/hooks/useWebViewHighlight.ts
@@ -1,0 +1,34 @@
+import { useMemo } from "react";
+
+/**
+ * Returns an injectJavaScript-compatible script that highlights a previously
+ * visited item in a WebView list, without changing the WebView source (which
+ * would trigger a full reload and corrupt pagination state).
+ *
+ * Items are matched by their `data-route-link` attribute.
+ */
+export function useWebViewHighlight(
+  previousUrl: string | undefined,
+  getRouteLink: (link: string) => string,
+): string | undefined {
+  return useMemo(() => {
+    if (!previousUrl) return undefined;
+
+    const routePath = getRouteLink(previousUrl);
+
+    return `
+      (function() {
+        var items = document.querySelectorAll('[data-route-link]');
+        items.forEach(function(el) {
+          var link = el.getAttribute('data-route-link');
+          if (link && link.includes(${JSON.stringify(routePath)})) {
+            el.style.setProperty('border-bottom-width', '5px');
+          } else {
+            el.style.removeProperty('border-bottom-width');
+          }
+        });
+      })();
+      true; // required by injectJavaScript — the script must evaluate to true
+    `;
+  }, [previousUrl, getRouteLink]);
+}

--- a/lib/horizontalNavigation/index.js
+++ b/lib/horizontalNavigation/index.js
@@ -125,30 +125,7 @@ const styles = `
 `;
 
 export const script = ({ ON_LOAD, HANDLE_LINK, HANDLE_ROUTER_LINK }) => `
-  const viewportEl = document.getElementById("viewport");
-  const articleEl = document.getElementById("article");
-  const viewportWidth = viewportEl.getBoundingClientRect().width;
-  const articleWidth = articleEl.getBoundingClientRect().width;
-
-  window.ReactNativeWebView.postMessage(JSON.stringify({
-    viewportWidth,
-    articleWidth,
-    eventName: '${ON_LOAD}',
-  }))
-
-  // send back to component the events created using 
-  // webviewRef.current?.postMessage(direction);
-  document.addEventListener("message", function(event) {
-    window.ReactNativeWebView.postMessage(JSON.stringify({
-      viewportWidth,
-      articleWidth,
-      eventName: event.data,
-    }))
-  }, false);
-
-  // Handle links
-  // Prevent links to execute default action
-  // Dispatch event with the href data
+  // Handle links — set up immediately so early taps are captured
   const links = document.querySelectorAll('a');
   const routeLinks = document.querySelectorAll('[data-route-link]');
 
@@ -168,7 +145,6 @@ export const script = ({ ON_LOAD, HANDLE_LINK, HANDLE_ROUTER_LINK }) => `
       event.preventDefault();
       const path = event.currentTarget.getAttribute('data-route-link');
 
-
       window.ReactNativeWebView.postMessage(JSON.stringify({
         path,
         eventName: '${HANDLE_ROUTER_LINK}',
@@ -177,6 +153,41 @@ export const script = ({ ON_LOAD, HANDLE_LINK, HANDLE_ROUTER_LINK }) => `
 
     link.addEventListener('click', handleClick);
   });
+
+  // Measure dimensions after CSS column-width reflow.
+  // getBoundingClientRect() can return 0 if the column layout hasn't been
+  // computed yet when injectedJavaScript runs — retry with rAF until ready.
+  let retries = 0;
+  function measureAndNotify() {
+    const viewportEl = document.getElementById("viewport");
+    const articleEl = document.getElementById("article");
+    const viewportWidth = viewportEl.getBoundingClientRect().width;
+    const articleWidth = articleEl.getBoundingClientRect().width;
+
+    if ((articleWidth === 0 || viewportWidth === 0) && retries < 10) {
+      retries++;
+      requestAnimationFrame(measureAndNotify);
+      return;
+    }
+
+    window.ReactNativeWebView.postMessage(JSON.stringify({
+      viewportWidth,
+      articleWidth,
+      eventName: '${ON_LOAD}',
+    }));
+
+    // Send back swipe events using the dimensions captured after layout.
+    // webviewRef.current?.postMessage(direction) triggers these.
+    document.addEventListener("message", function(event) {
+      window.ReactNativeWebView.postMessage(JSON.stringify({
+        viewportWidth,
+        articleWidth,
+        eventName: event.data,
+      }))
+    }, false);
+  }
+
+  requestAnimationFrame(measureAndNotify);
 `;
 
 export function getHorizontalNavigationPage({ content, width, theme }) {

--- a/lib/horizontalNavigation/index.js
+++ b/lib/horizontalNavigation/index.js
@@ -124,7 +124,13 @@ const styles = `
   }
 `;
 
-export const script = ({ ON_LOAD, HANDLE_LINK, HANDLE_ROUTER_LINK }) => `
+export const script = ({
+  ON_LOAD,
+  ON_LOAD_ERROR,
+  HANDLE_LINK,
+  HANDLE_ROUTER_LINK,
+  _CONSOLE_,
+}) => `
   // Handle links — set up immediately so early taps are captured
   const links = document.querySelectorAll('a');
   const routeLinks = document.querySelectorAll('[data-route-link]');
@@ -167,6 +173,16 @@ export const script = ({ ON_LOAD, HANDLE_LINK, HANDLE_ROUTER_LINK }) => `
     if ((articleWidth === 0 || viewportWidth === 0) && retries < 10) {
       retries++;
       requestAnimationFrame(measureAndNotify);
+      return;
+    }
+
+    if (articleWidth === 0 || viewportWidth === 0) {
+      // Layout still broken after max retries — skip ON_LOAD to avoid
+      // corrupting pagination state with 0 dimensions.
+      window.ReactNativeWebView.postMessage(JSON.stringify({
+        message: 'measureAndNotify: dimensions still 0 after 10 rAF retries. ON_LOAD skipped.',
+        eventName: '${ON_LOAD_ERROR}',
+      }));
       return;
     }
 

--- a/theme/fonts.ts
+++ b/theme/fonts.ts
@@ -55,7 +55,7 @@ export function getFonts(baseFontSize: number): Fonts {
     fontSizeSmall: baseFontSize * 0.8,
     fontSizeCode: baseFontSize * 0.7,
 
-    lineHeightMinimal: baseFontSize * 1,
+    lineHeightMinimal: baseFontSize * 1.15,
     lineHeightSmall: baseFontSize * 1.3,
     lineHeightComfortable: baseFontSize * 1.4,
     lineHeightCode: baseFontSize * 0.7 * 1.2,


### PR DESCRIPTION
Fix pages.amount/pages.current corrupting on navigation back
- Remove previousArticleUrl from the WebView source html — replaced with a postLoadScript injected via injectJavaScript so the WebView doesn't reload on focus
- Memoize content and source in HTMLPagesNav to prevent unnecessary WebView reloads
- Wrap injectedJavaScript dimension measurement in requestAnimationFrame with retry to ensure CSS column-width layout is complete before reading getBoundingClientRect()
- Remove useFocusEffect scroll restoration (no longer needed since the WebView preserves its DOM state)
- Fix useFocusEffect callback to use useCallback as required by React Navigation
- Update feed list paddings 